### PR TITLE
Allow Widget to be preset with from/to tokens using props

### DIFF
--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -182,7 +182,6 @@ export function FieldWrapper({
         currency={currency}
         loading={isLoading}
         approved={approved}
-        presetValue={!!presetCurrency}
         disabled={isDisabled}
         isDependentField={isDependentField}
         onChangeInput={updateAmount}

--- a/src/components/Swap/TokenInput.tsx
+++ b/src/components/Swap/TokenInput.tsx
@@ -44,7 +44,6 @@ interface TokenInputProps {
   isDependentField?: boolean
   onChangeInput: (input: string) => void
   onChangeCurrency: (currency: Currency) => void
-  presetValue?: boolean
 }
 
 export const TokenInput = forwardRef<TokenInputHandle, PropsWithChildren<TokenInputProps>>(function TokenInput(
@@ -56,7 +55,6 @@ export const TokenInput = forwardRef<TokenInputHandle, PropsWithChildren<TokenIn
     loading,
     disabled,
     isDependentField,
-    presetValue,
     onChangeInput,
     onChangeCurrency,
     children,
@@ -102,7 +100,6 @@ export const TokenInput = forwardRef<TokenInputHandle, PropsWithChildren<TokenIn
           disabled={disabled}
           onSelect={onSelect}
           chainIdsAllowed={chainIdsAllowed}
-          presetValue={presetValue}
           tokenList={tokenList}
         />
         <ThemedText.H2>

--- a/src/components/TokenSelect/TokenButton.tsx
+++ b/src/components/TokenSelect/TokenButton.tsx
@@ -3,26 +3,17 @@ import { Currency } from '@uniswap/sdk-core'
 import { getChainInfo } from 'constants/chainInfo'
 import { getNativeLogoURI } from 'hooks/useCurrencyLogoURIs'
 import { ChevronDown } from 'icons'
-import styled, { css } from 'styled-components/macro'
+import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 
 import Button from '../Button'
 import Row from '../Row'
 import TokenImg, { ChainImgBadge, TokenGroup } from '../TokenImg'
 
-const presetValueCss = css`
-  cursor: initial;
-  :hover:enabled {
-    background-color: ${({ theme }) => theme['interactive']};
-  }
-`
-
 const StyledTokenButton = styled(Button)<{ approved?: boolean; presetValue?: boolean }>`
   border-radius: ${({ theme }) => theme.borderRadius.medium}em;
   min-height: 2em;
   padding: 0.25em 0.5em 0.25em 0.25em;
-
-  ${({ presetValue }) => presetValue && presetValueCss};
 
   :enabled {
     transition: none;
@@ -63,21 +54,19 @@ interface TokenButtonProps {
   approved?: boolean
   disabled?: boolean
   onClick: () => void
-  presetValue?: boolean
 }
 
-export default function TokenButton({ value, approved, disabled, onClick, presetValue }: TokenButtonProps) {
+export default function TokenButton({ value, approved, disabled, onClick }: TokenButtonProps) {
   const chainInfo = getChainInfo(value?.chainId)
   const chainSrc = getNativeLogoURI(value?.chainId)
 
   return (
     <StyledTokenButton
-      onClick={presetValue ? undefined : onClick}
+      onClick={onClick}
       color={value ? 'interactive' : 'accent'}
       approved={approved}
       disabled={disabled}
       data-testid="token-select"
-      presetValue={presetValue}
     >
       <TokenButtonRow empty={!value} flex gap={0.4}>
         {value ? (
@@ -96,7 +85,7 @@ export default function TokenButton({ value, approved, disabled, onClick, preset
             <Trans>Select token</Trans>
           </ThemedText.ButtonLarge>
         )}
-        {!presetValue && <DropDownIcon strokeWidth={2} color={value ? 'primary' : 'onAccent'} />}
+        <DropDownIcon strokeWidth={2} color={value ? 'primary' : 'onAccent'} />
       </TokenButtonRow>
     </StyledTokenButton>
   )

--- a/src/components/TokenSelect/index.tsx
+++ b/src/components/TokenSelect/index.tsx
@@ -163,7 +163,6 @@ interface TokenSelectProps {
   disabled?: boolean
   onSelect: (value: Currency) => void
   chainIdsAllowed: number[]
-  presetValue?: boolean
   tokenList: TokenListItem[]
 }
 
@@ -174,7 +173,6 @@ export default memo(function TokenSelect({
   disabled,
   onSelect,
   chainIdsAllowed,
-  presetValue,
   tokenList,
 }: TokenSelectProps) {
   usePrefetchBalances()
@@ -193,7 +191,7 @@ export default memo(function TokenSelect({
   )
   return (
     <>
-      <TokenButton value={value} approved={approved} disabled={disabled} presetValue={presetValue} onClick={onOpen} />
+      <TokenButton value={value} approved={approved} disabled={disabled} onClick={onOpen} />
       {open && (
         <TokenSelectDialog
           value={value}

--- a/src/cosmos/WidgetPreset.fixture.tsx
+++ b/src/cosmos/WidgetPreset.fixture.tsx
@@ -1,0 +1,198 @@
+import { Web3Provider } from '@ethersproject/providers'
+import { useWeb3React, Web3ReactProvider } from '@web3-react/core'
+import { InjectedConnector } from '@web3-react/injected-connector'
+import Column from 'components/Column'
+import Row from 'components/Row'
+import { connect, disconnect, IStarknetWindowObject } from 'get-starknet'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useValue } from 'react-cosmos/fixture'
+import { getSupportedTokens, quote, useLocalApi, useProdApi } from 'wido'
+import { darkTheme, defaultTheme, isStarknetChain, lightTheme, WidoWidget } from 'wido-widget'
+
+import EventFeed, { Event, HANDLERS } from './EventFeed'
+
+function Fixture() {
+  const [events, setEvents] = useState<Event[]>([])
+  const useHandleEvent = useCallback(
+    (name: string) =>
+      (...data: unknown[]) =>
+        setEvents((events) => [{ name, data }, ...events]),
+    []
+  )
+
+  const [width] = useValue('width', { defaultValue: 420 })
+
+  // const locales = [...SUPPORTED_LOCALES, 'fa-KE (unsupported)', 'pseudo']
+  // const locale = useOption('locale', { options: locales, defaultValue: DEFAULT_LOCALE, nullable: false })
+
+  const [theme, setTheme] = useValue('theme', { defaultValue: defaultTheme })
+  const [darkMode] = useValue('darkMode', { defaultValue: false })
+  const [largeTokenSelect] = useValue('largeTokenSelect', { defaultValue: false })
+
+  useEffect(() => setTheme((theme) => ({ ...theme, ...(darkMode ? darkTheme : lightTheme) })), [darkMode, setTheme])
+
+  const eventHandlers = useMemo(
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    () => HANDLERS.reduce((handlers, name) => ({ ...handlers, [name]: useHandleEvent(name) }), {}),
+    [useHandleEvent]
+  )
+  const { library, activate, deactivate, account, chainId } = useWeb3React()
+
+  const [ethProvider, setEthProvider] = useState<Web3Provider | undefined>()
+
+  useEffect(() => {
+    if (!library) return
+    // every time account or chainId changes we need to re-create the provider
+    // for the widget to update with the proper address
+    setEthProvider(new Web3Provider(library))
+  }, [library, account, chainId, setEthProvider])
+
+  const handleMetamask = useCallback(async () => {
+    if (ethProvider) {
+      deactivate()
+    } else {
+      await activate(injected)
+    }
+  }, [ethProvider, activate, deactivate])
+
+  const [starknet, setStarknet] = useState<IStarknetWindowObject | undefined>()
+
+  const handleStarknet = useCallback(async () => {
+    if (starknet) {
+      setStarknet(undefined)
+      disconnect()
+    } else {
+      const connection = await connect()
+      await connection?.enable()
+      setStarknet(connection)
+      connection?.on('networkChanged', () => setStarknet(undefined))
+      connection?.on('accountsChanged', () => setStarknet(undefined))
+    }
+  }, [starknet, setStarknet])
+
+  const [localApi] = useValue('localApi', { defaultValue: false })
+  if (localApi) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useLocalApi()
+  } else {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useProdApi()
+  }
+
+  const [presetFromChainIds] = useValue('presetFromChainIds', {
+    defaultValue: '[1,5,137,250,15367,1313161554]',
+    // defaultValue: '[5]',
+  })
+  const [presetToChainIds] = useValue('presetToChainIds', {
+    defaultValue: '[1,137,250,15367,1313161554]',
+    // defaultValue: '[15367]',
+  })
+  const [presetFromToken] = useValue('presetFromToken', { defaultValue: false })
+  const [presetToToken] = useValue('presetToToken', { defaultValue: false })
+  const [presetToProtocol] = useValue('presetToProtocol', { defaultValue: false })
+
+  const [fromTokens, setFromTokens] = useState<{ chainId: number; address: string }[]>([])
+  const [toTokens, setToTokens] = useState<{ chainId: number; address: string }[]>([])
+
+  useEffect(() => {
+    if (presetFromToken) {
+      setFromTokens([
+        {
+          chainId: 5,
+          address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+        },
+      ])
+    } else {
+      getSupportedTokens({
+        chainId: JSON.parse(presetFromChainIds),
+      }).then(setFromTokens)
+    }
+  }, [presetFromToken, setFromTokens, presetFromChainIds])
+
+  useEffect(() => {
+    if (presetToToken) {
+      setToTokens([
+        {
+          chainId: 15367,
+          address: '0x5a643907b9a4bc6a55e9069c4fd5fd1f5c79a22470690f75556c4736e34426',
+        },
+      ])
+    } else {
+      getSupportedTokens({
+        chainId: JSON.parse(presetToChainIds),
+        protocol: presetToProtocol ? ['jediswap.xyz' as any] : undefined,
+      }).then(setToTokens)
+    }
+  }, [presetToToken, setToTokens, presetToChainIds, presetToProtocol])
+
+  const handleConnectWalletClick = useCallback(
+    (chainId: number) => {
+      if ('onConnectWalletClick' in eventHandlers) {
+        ;(eventHandlers as any)['onConnectWalletClick'](chainId)
+      }
+
+      if (isStarknetChain(chainId)) {
+        handleStarknet()
+      } else {
+        handleMetamask()
+      }
+    },
+    [handleStarknet, handleMetamask, eventHandlers]
+  )
+
+  const widget = (
+    <WidoWidget
+      partner="0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+      ethProvider={ethProvider}
+      snAccount={starknet?.account}
+      theme={theme}
+      width={width}
+      fromTokens={fromTokens}
+      toTokens={toTokens}
+      presetFromToken={{
+        chainId: 1,
+        address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+      }}
+      presetToToken={{
+        chainId: 137,
+        address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+      }}
+      quoteApi={(request) => {
+        // place to override the quote request or result
+        return quote(request)
+      }}
+      {...eventHandlers}
+      onConnectWalletClick={handleConnectWalletClick}
+      largeTokenSelect={largeTokenSelect}
+    />
+  )
+
+  // If framed in a different origin, only display the SwapWidget, without any chrome.
+  // This is done to faciliate iframing in the documentation (https://docs.uniswap.org).
+  if (!window.frameElement) return widget
+
+  return (
+    <Column flex align="start" justify="start" gap={0.5}>
+      <Row flex align="start" justify="start" gap={0.5}>
+        {widget}
+        <EventFeed events={events} onClear={() => setEvents([])} />
+      </Row>
+      <Column flex align="start" justify="start" gap={0.5}>
+        <span>Starknet Address: {starknet?.account?.address}</span>
+        <span>Starknet ChainId: {starknet?.account?.chainId}</span>
+        <span>EVM Address: {account}</span>
+        <span>EVM ChainId: {chainId}</span>
+      </Column>
+    </Column>
+  )
+}
+
+export const injected = new InjectedConnector({})
+
+export default function App() {
+  return (
+    <Web3ReactProvider getLibrary={(provider) => provider}>
+      <Fixture />
+    </Web3ReactProvider>
+  )
+}

--- a/src/hooks/swap/index.ts
+++ b/src/hooks/swap/index.ts
@@ -5,6 +5,7 @@ import { useCallback, useMemo } from 'react'
 import { pickAtom } from 'state/atoms'
 import { Field, swapAtom, swapEventHandlersAtom } from 'state/swap'
 import { toTradeType } from 'utils/tradeType'
+import { userSelectedFromToken, userSelectedToToken } from '../useSyncWidgetSettings';
 export { ChainError, default as useSwapInfo } from './useSwapInfo'
 
 function otherField(field: Field) {
@@ -38,6 +39,8 @@ export function useSwapCurrency(field: Field): [Currency | undefined, (currency:
   const otherCurrencyAtom = useMemo(() => pickAtom(swapAtom, otherField(field)), [field])
   const otherCurrency = useAtomValue(otherCurrencyAtom)
   const { onFromTokenChange, onToTokenChange } = useAtomValue(swapEventHandlersAtom)
+  const setUserSelectedToToken = useUpdateAtom(userSelectedToToken)
+  const setUserSelectedFromToken = useUpdateAtom(userSelectedFromToken)
   const switchSwapCurrencies = useSwitchSwapCurrencies()
   const setOrSwitchCurrency = useCallback(
     (update: Currency) => {
@@ -46,8 +49,10 @@ export function useSwapCurrency(field: Field): [Currency | undefined, (currency:
         switchSwapCurrencies()
       } else {
         if (field === Field.INPUT) {
+          setUserSelectedToToken(true)
           onFromTokenChange?.(update)
         } else {
+          setUserSelectedFromToken(true)
           onToTokenChange?.(update)
         }
         setCurrency(update)

--- a/src/hooks/useSyncWidgetSettings.ts
+++ b/src/hooks/useSyncWidgetSettings.ts
@@ -21,8 +21,8 @@ export interface WidgetSettings {
   snAccount?: AccountInterface
   toTokens?: { chainId: number; address: string }[]
   fromTokens?: { chainId: number; address: string }[]
-  presetToToken?: { chainId: number; address: string }
-  presetFromToken?: { chainId: number; address: string }
+  presetToToken?: { chainId: number; address: string } | undefined
+  presetFromToken?: { chainId: number; address: string } | undefined
   partner?: string
   quoteApi?: (request: QuoteRequest) => Promise<QuoteResult>
   /**

--- a/src/hooks/useSyncWidgetSettings.ts
+++ b/src/hooks/useSyncWidgetSettings.ts
@@ -7,8 +7,14 @@ import { isStarknetChain } from 'utils/starknet'
 import { quote, QuoteRequest, QuoteResult } from 'wido'
 
 export const widgetSettingsAtom = atom<WidgetSettings>({})
-export const userSelectedToToken = atom<boolean>(false)
+/**
+ * Stores whether the user selected a `from` token on the UI
+ */
 export const userSelectedFromToken = atom<boolean>(false)
+/**
+ * Stores whether the user selected a `to` token on the UI
+ */
+export const userSelectedToToken = atom<boolean>(false)
 
 export interface WidgetSettings {
   ethProvider?: Web3Provider
@@ -153,33 +159,49 @@ export function useRecipientAddress(chainId: number) {
   }
 }
 
+/**
+ * Checks if a preset token should be used in the `From` field
+ * If it is the case, it returns the token, otherwise undefined, meaning no preset.
+ */
 export function useWidgetFromToken() {
   const { fromTokens, presetFromToken } = useAtomValue(widgetSettingsAtom)
   const userHasSelected = useAtomValue(userSelectedFromToken)
+  // if the user selected something, no preset token
   if (userHasSelected) {
     return undefined
   }
+  // if only one token on the list, that should be the preset
   if (fromTokens && Array.isArray(fromTokens) && fromTokens.length === 1) {
     return fromTokens[0]
   }
+  // if a preset is given by props, that should be the preset
   if (presetFromToken && presetFromToken.chainId && presetFromToken.address) {
     return presetFromToken
   }
+  // otherwise none
   return undefined
 }
 
+/**
+ * Checks if a preset token should be used in the `To` field
+ * If it is the case, it returns the token, otherwise undefined, meaning no preset.
+ */
 export function useWidgetToToken() {
   const { toTokens, presetToToken } = useAtomValue(widgetSettingsAtom)
   const userHasSelected = useAtomValue(userSelectedToToken)
+  // if the user selected something, no preset token
   if (userHasSelected) {
     return undefined
   }
+  // if only one token on the list, that should be the preset
   if (toTokens && Array.isArray(toTokens) && toTokens.length === 1) {
     return toTokens[0]
   }
+  // if a preset is given by props, that should be the preset
   if (presetToToken && presetToToken.chainId && presetToToken.address) {
     return presetToToken
   }
+  // otherwise none
   return undefined
 }
 

--- a/src/hooks/useSyncWidgetSettings.ts
+++ b/src/hooks/useSyncWidgetSettings.ts
@@ -7,12 +7,16 @@ import { isStarknetChain } from 'utils/starknet'
 import { quote, QuoteRequest, QuoteResult } from 'wido'
 
 export const widgetSettingsAtom = atom<WidgetSettings>({})
+export const userSelectedToToken = atom<boolean>(false)
+export const userSelectedFromToken = atom<boolean>(false)
 
 export interface WidgetSettings {
   ethProvider?: Web3Provider
   snAccount?: AccountInterface
   toTokens?: { chainId: number; address: string }[]
   fromTokens?: { chainId: number; address: string }[]
+  presetToToken?: { chainId: number; address: string }
+  presetFromToken?: { chainId: number; address: string }
   partner?: string
   quoteApi?: (request: QuoteRequest) => Promise<QuoteResult>
   /**
@@ -32,6 +36,8 @@ export default function useSyncWidgetSettings({
   snAccount,
   toTokens,
   fromTokens,
+  presetToToken,
+  presetFromToken,
   partner,
   quoteApi,
   title,
@@ -44,6 +50,8 @@ export default function useSyncWidgetSettings({
       snAccount,
       toTokens,
       fromTokens,
+      presetToToken,
+      presetFromToken,
       partner,
       quoteApi,
       title,
@@ -55,6 +63,8 @@ export default function useSyncWidgetSettings({
     snAccount,
     toTokens,
     fromTokens,
+    presetToToken,
+    presetFromToken,
     partner,
     quoteApi,
     title,
@@ -144,17 +154,31 @@ export function useRecipientAddress(chainId: number) {
 }
 
 export function useWidgetFromToken() {
-  const { fromTokens } = useAtomValue(widgetSettingsAtom)
+  const { fromTokens, presetFromToken } = useAtomValue(widgetSettingsAtom)
+  const userHasSelected = useAtomValue(userSelectedFromToken)
+  if (userHasSelected) {
+    return undefined
+  }
   if (fromTokens && Array.isArray(fromTokens) && fromTokens.length === 1) {
     return fromTokens[0]
+  }
+  if (presetFromToken && presetFromToken.chainId && presetFromToken.address) {
+    return presetFromToken
   }
   return undefined
 }
 
 export function useWidgetToToken() {
-  const { toTokens } = useAtomValue(widgetSettingsAtom)
+  const { toTokens, presetToToken } = useAtomValue(widgetSettingsAtom)
+  const userHasSelected = useAtomValue(userSelectedToToken)
+  if (userHasSelected) {
+    return undefined
+  }
   if (toTokens && Array.isArray(toTokens) && toTokens.length === 1) {
     return toTokens[0]
+  }
+  if (presetToToken && presetToToken.chainId && presetToToken.address) {
+    return presetToToken
   }
   return undefined
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,8 +33,8 @@ export type WidoWidgetProps = {
   snAccount?: AccountInterface
   toTokens?: { chainId: number; address: string }[]
   fromTokens?: { chainId: number; address: string }[]
-  presetToToken?: { chainId: number; address: string }
-  presetFromToken?: { chainId: number; address: string }
+  presetToToken?: { chainId: number; address: string } | undefined
+  presetFromToken?: { chainId: number; address: string } | undefined
   partner?: string
 
   // WidgetProps

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,8 @@ export type WidoWidgetProps = {
   snAccount?: AccountInterface
   toTokens?: { chainId: number; address: string }[]
   fromTokens?: { chainId: number; address: string }[]
+  presetToToken?: { chainId: number; address: string }
+  presetFromToken?: { chainId: number; address: string }
   partner?: string
 
   // WidgetProps


### PR DESCRIPTION
Widget manages its own state, therefore setting the fromToken or toToken from the outside was not an option.

To achieve this we allow a preset selection to be given by props, and the widget will show that as a default until the user selects something else using the UI, at that point the presets become irrelevant and are not used anymore.

Given this change, now the UI will always allow the user to select a token, even if there is a preset, even if there's only one token, therefore some logic to block the interface when preset was enabled is gone.
