### PR TITLE
Update peer dependency requirement for react-redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "ethers": "^5.6.1",
     "react": ">=17.0.1",
     "react-dom": ">=17.0.1",
-    "react-redux": ">=7.2.2",
+    "react-redux": ">=8.0.5",
     "redux": ">=4.1.2",
     "styled-components": ">=5"
   },


### PR DESCRIPTION
Users trying to integrate face the following error
<img width="323" alt="image" src="https://github.com/Uniswap/widgets/assets/435610/a61423ac-947d-4901-baa3-81c53e4897ec">

One of them was able to solve it after upgrading `react-redux` version.

But there are cases out there where they still face the same issue.