### PR TITLE
Line-shift for lengthy pair name-amount

### DIFF
--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -10,6 +10,7 @@ export interface ColumnProps {
   flex?: true
   grow?: true
   css?: ReturnType<typeof css>
+  width?: string
 }
 
 const Column = styled.div<ColumnProps>`
@@ -23,6 +24,7 @@ const Column = styled.div<ColumnProps>`
   grid-template-columns: 1fr;
   justify-content: ${({ justify }) => justify ?? 'space-between'};
   padding: ${({ padded }) => padded && '0.75em'};
+  width: ${({ width }) => width ?? 'auto'};
 
   ${({ css }) => css}
 `

--- a/src/components/Row.tsx
+++ b/src/components/Row.tsx
@@ -12,6 +12,7 @@ export interface RowProps {
   grow?: true | 'first' | 'last'
   children?: ReactNode
   theme: Theme
+  width?: string
 }
 
 const Row = styled.div<RowProps>`
@@ -30,6 +31,7 @@ const Row = styled.div<RowProps>`
   }};
   justify-content: ${({ justify }) => justify ?? 'space-between'};
   padding: ${({ pad }) => pad && `0 ${pad}em`};
+  width: ${({ width }) => width ?? 'auto'};
 `
 
 export default Row

--- a/src/components/Swap/Summary/Details.tsx
+++ b/src/components/Swap/Summary/Details.tsx
@@ -49,6 +49,10 @@ const RuleWrapper = styled.div`
   margin: 0.75em 0.125em;
 `
 
+const AmountValue = styled.span`
+  display: inline-block;
+`
+
 const MAX_AMOUNT_STR_LENGTH = 9
 
 interface DetailProps {
@@ -97,7 +101,7 @@ function Amount({ tooltipText, label, amount, usdcAmount }: AmountProps) {
   }
 
   return (
-    <Row flex align="flex-start">
+    <Row flex align="flex-start" width="100%">
       <Row>
         <ThemedText.Body2 userSelect>
           <Label>{label}</Label>
@@ -109,9 +113,17 @@ function Amount({ tooltipText, label, amount, usdcAmount }: AmountProps) {
         )}
       </Row>
 
-      <Column flex align="flex-end" grow>
-        <ThemedText.H1 color="primary" fontSize={amountFontSize} lineHeight={amountLineHeight}>
-          {amount.toExact()} {amount.currency.symbol}
+      <Column flex align="flex-end" grow width="80%">
+        <ThemedText.H1
+          color="primary"
+          fontSize={amountFontSize}
+          lineHeight={amountLineHeight}
+          textAlign="right"
+          style={{ whiteSpace: 'pre-wrap' }}
+          paddingLeft={'1rem'}
+        >
+          <AmountValue>{amount.toExact()}</AmountValue>
+          <AmountValue>&nbsp;{amount.currency.symbol}</AmountValue>
         </ThemedText.H1>
         {usdcAmount && (
           <ThemedText.Body2>


### PR DESCRIPTION
Updated the layout to shift the pair name to a new line when the name-number combination gets too long.