### PR TITLE
Add natives details

### DIFF
--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -447,6 +447,13 @@ export const WRAPPED_NATIVE_CURRENCY: { [chainId: number]: Token | undefined } =
     'WMATIC',
     'Wrapped MATIC'
   ),
+  [SupportedChainId.BSC]: new Token(
+    SupportedChainId.BSC,
+    '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+    18,
+    'WBNB',
+    'Wrapped BNB'
+  ),
 }
 
 export function isCelo(chainId: number): chainId is SupportedChainId.CELO | SupportedChainId.CELO_ALFAJORES {

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -468,6 +468,10 @@ function isMatic(chainId: number): chainId is SupportedChainId.POLYGON | Support
   return chainId === SupportedChainId.POLYGON_MUMBAI || chainId === SupportedChainId.POLYGON
 }
 
+function isBSC(chainId: number): boolean {
+  return chainId === SupportedChainId.BSC
+}
+
 class MaticNativeCurrency extends NativeCurrency {
   equals(other: Currency): boolean {
     return other.isNative && other.chainId === this.chainId
@@ -483,6 +487,24 @@ class MaticNativeCurrency extends NativeCurrency {
   public constructor(chainId: number) {
     if (!isMatic(chainId)) throw new Error('Not matic')
     super(chainId, 18, 'MATIC', 'Polygon Matic')
+  }
+}
+
+class BSCNativeCurrency extends NativeCurrency {
+  equals(other: Currency): boolean {
+    return other.isNative && other.chainId === this.chainId
+  }
+
+  get wrapped(): Token {
+    if (!isBSC(this.chainId)) throw new Error('Not BSC')
+    const wrapped = WRAPPED_NATIVE_CURRENCY[this.chainId]
+    invariant(wrapped instanceof Token)
+    return wrapped
+  }
+
+  public constructor(chainId: number) {
+    if (!isBSC(chainId)) throw new Error('Not BSC')
+    super(chainId, 18, 'BNB', 'BNB')
   }
 }
 
@@ -508,6 +530,8 @@ export function nativeOnChain(chainId: number): NativeCurrency | Token {
     nativeCurrency = new MaticNativeCurrency(chainId)
   } else if (isCelo(chainId)) {
     nativeCurrency = getCeloNativeCurrency(chainId)
+  } else if (isBSC(chainId)) {
+    nativeCurrency = new BSCNativeCurrency(chainId)
   } else {
     nativeCurrency = ExtendedEther.onChain(chainId)
   }

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -454,6 +454,13 @@ export const WRAPPED_NATIVE_CURRENCY: { [chainId: number]: Token | undefined } =
     'WBNB',
     'Wrapped BNB'
   ),
+  [SupportedChainId.FANTOM]: new Token(
+    SupportedChainId.FANTOM,
+    '0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83',
+    18,
+    'WFTM',
+    'Wrapped FTM'
+  ),
 }
 
 export function isCelo(chainId: number): chainId is SupportedChainId.CELO | SupportedChainId.CELO_ALFAJORES {
@@ -477,6 +484,10 @@ function isMatic(chainId: number): chainId is SupportedChainId.POLYGON | Support
 
 function isBSC(chainId: number): boolean {
   return chainId === SupportedChainId.BSC
+}
+
+function isFantom(chainId: number): boolean {
+  return chainId === SupportedChainId.FANTOM
 }
 
 class MaticNativeCurrency extends NativeCurrency {
@@ -515,6 +526,24 @@ class BSCNativeCurrency extends NativeCurrency {
   }
 }
 
+class FantomNativeCurrency extends NativeCurrency {
+  equals(other: Currency): boolean {
+    return other.isNative && other.chainId === this.chainId
+  }
+
+  get wrapped(): Token {
+    if (!isFantom(this.chainId)) throw new Error('Not Fantom')
+    const wrapped = WRAPPED_NATIVE_CURRENCY[this.chainId]
+    invariant(wrapped instanceof Token)
+    return wrapped
+  }
+
+  public constructor(chainId: number) {
+    if (!isFantom(chainId)) throw new Error('Not Fantom')
+    super(chainId, 18, 'FTM', 'FTM')
+  }
+}
+
 export class ExtendedEther extends Ether {
   public get wrapped(): Token {
     const wrapped = WRAPPED_NATIVE_CURRENCY[this.chainId]
@@ -539,6 +568,8 @@ export function nativeOnChain(chainId: number): NativeCurrency | Token {
     nativeCurrency = getCeloNativeCurrency(chainId)
   } else if (isBSC(chainId)) {
     nativeCurrency = new BSCNativeCurrency(chainId)
+  } else if (isFantom(chainId)) {
+    nativeCurrency = new FantomNativeCurrency(chainId)
   } else {
     nativeCurrency = ExtendedEther.onChain(chainId)
   }

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -461,6 +461,13 @@ export const WRAPPED_NATIVE_CURRENCY: { [chainId: number]: Token | undefined } =
     'WFTM',
     'Wrapped FTM'
   ),
+  [SupportedChainId.AVALANCHE]: new Token(
+    SupportedChainId.AVALANCHE,
+    '0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7',
+    18,
+    'WAVAX',
+    'Wrapped AVAX'
+  ),
 }
 
 export function isCelo(chainId: number): chainId is SupportedChainId.CELO | SupportedChainId.CELO_ALFAJORES {
@@ -488,6 +495,10 @@ function isBSC(chainId: number): boolean {
 
 function isFantom(chainId: number): boolean {
   return chainId === SupportedChainId.FANTOM
+}
+
+function isAvalanche(chainId: number): boolean {
+  return chainId === SupportedChainId.AVALANCHE
 }
 
 class MaticNativeCurrency extends NativeCurrency {
@@ -544,6 +555,24 @@ class FantomNativeCurrency extends NativeCurrency {
   }
 }
 
+class AvalancheNativeCurrency extends NativeCurrency {
+  equals(other: Currency): boolean {
+    return other.isNative && other.chainId === this.chainId
+  }
+
+  get wrapped(): Token {
+    if (!isAvalanche(this.chainId)) throw new Error('Not Avalanche')
+    const wrapped = WRAPPED_NATIVE_CURRENCY[this.chainId]
+    invariant(wrapped instanceof Token)
+    return wrapped
+  }
+
+  public constructor(chainId: number) {
+    if (!isAvalanche(chainId)) throw new Error('Not Avalanche')
+    super(chainId, 18, 'AVAX', 'AVAX')
+  }
+}
+
 export class ExtendedEther extends Ether {
   public get wrapped(): Token {
     const wrapped = WRAPPED_NATIVE_CURRENCY[this.chainId]
@@ -570,6 +599,8 @@ export function nativeOnChain(chainId: number): NativeCurrency | Token {
     nativeCurrency = new BSCNativeCurrency(chainId)
   } else if (isFantom(chainId)) {
     nativeCurrency = new FantomNativeCurrency(chainId)
+  } else if (isAvalanche(chainId)) {
+    nativeCurrency = new AvalancheNativeCurrency(chainId)
   } else {
     nativeCurrency = ExtendedEther.onChain(chainId)
   }


### PR DESCRIPTION
Adds details for the native tokens of Avalance, Fantom and BSC, so they appear with their real name in the token list.