### PR TITLE
fix: action button effet & label

### DIFF
--- a/src/components/Swap/SwapActionButton/SwapButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwapButton.tsx
@@ -38,6 +38,7 @@ export default function SwapButton({ disabled }: { disabled: boolean }) {
   const color = useTokenColorExtraction()
   const isAmountPopulated = useIsAmountPopulated()
   const missingInput = inputCurrency != null && outputCurrency != null && !isAmountPopulated
+  const missingCurrency = !inputCurrency || !outputCurrency
 
   const permit2Enabled = usePermit2Enabled()
   const { callback: swapCallback } = useSwapCallback({
@@ -94,7 +95,7 @@ export default function SwapButton({ disabled }: { disabled: boolean }) {
   return (
     <>
       <ActionButton color={color} onClick={onClick} disabled={disabled}>
-        <Trans>{missingInput ? 'Enter an amount' : 'Review'}</Trans>
+        <Trans>{missingInput ? 'Enter an amount' : missingCurrency ? 'Select token' : 'Review'}</Trans>
       </ActionButton>
       {open && trade && (
         <Dialog color="container" onClose={() => setOpen(false)}>

--- a/src/components/Swap/SwapActionButton/index.tsx
+++ b/src/components/Swap/SwapActionButton/index.tsx
@@ -3,6 +3,8 @@ import { ChainError, useSwapInfo } from 'hooks/swap'
 import { SwapApprovalState } from 'hooks/swap/useSwapApproval'
 import { useIsWrap } from 'hooks/swap/useWrapCallback'
 import { useEvmAccountAddress, useSnAccountAddress } from 'hooks/useSyncWidgetSettings'
+import { widgetSettingsAtom } from 'hooks/useSyncWidgetSettings'
+import { useAtomValue } from 'jotai/utils'
 import { useMemo } from 'react'
 import { Field } from 'state/swap'
 import { isStarknetChain } from 'utils/starknet'
@@ -35,8 +37,25 @@ export default function SwapActionButton() {
   const srcWalletConnected = isStarknetChain(inputCurrency?.chainId) ? snAccount : account
   const dstWalletConnected = isStarknetChain(outputCurrency?.chainId) ? snAccount : account
 
+  const { toTokens, fromTokens } = useAtomValue(widgetSettingsAtom)
+  const fromTokensCommonChainId =
+    fromTokens &&
+    fromTokens[0] &&
+    (fromTokens.every((t) => t.chainId === fromTokens[0].chainId) ? fromTokens[0].chainId : undefined)
+  const toTokensCommonChainId =
+    toTokens &&
+    toTokens[0] &&
+    (toTokens.every((t) => t.chainId === toTokens[0].chainId) ? toTokens[0].chainId : undefined)
+  const isDstStarknet = isStarknetChain(toTokensCommonChainId)
+
   if (!inputCurrency && !outputCurrency) {
-    return <SwapButton disabled={isDisabled} />
+    if (fromTokensCommonChainId && !srcWalletConnected) {
+      return <ConnectWalletButton chainId={fromTokensCommonChainId} />
+    } else if (toTokensCommonChainId && isDstStarknet && !dstWalletConnected) {
+      return <ConnectWalletButton chainId={toTokensCommonChainId} />
+    } else {
+      return <SwapButton disabled={isDisabled} />
+    }
   } else if (inputCurrency && !srcWalletConnected) {
     return <ConnectWalletButton chainId={inputCurrency.chainId} />
   } else if (outputCurrency && !dstWalletConnected) {

--- a/src/components/Swap/SwapActionButton/index.tsx
+++ b/src/components/Swap/SwapActionButton/index.tsx
@@ -46,14 +46,21 @@ export default function SwapActionButton() {
     toTokens &&
     toTokens[0] &&
     (toTokens.every((t) => t.chainId === toTokens[0].chainId) ? toTokens[0].chainId : undefined)
-  const isDstStarknet = isStarknetChain(toTokensCommonChainId)
+  const isToTokensEVM = toTokens && toTokens.every((t) => !isStarknetChain(t.chainId))
+  const isFromTokensEVM = fromTokens && fromTokens.every((t) => !isStarknetChain(t.chainId))
 
   if (!inputCurrency && !outputCurrency) {
-    if (fromTokensCommonChainId && !srcWalletConnected) {
+    if (fromTokensCommonChainId && (isStarknetChain(fromTokensCommonChainId) ? !snAccount : !account)) {
+      // If the 'From' tokens are on the same chain then a 'Connect' button with this chain should appear
       return <ConnectWalletButton chainId={fromTokensCommonChainId} />
-    } else if (toTokensCommonChainId && isDstStarknet && !dstWalletConnected) {
+    } else if ((isToTokensEVM || isFromTokensEVM) && !account) {
+      // If the 'From' or 'To' tokens are on the EVM chain then a 'Connect' button with the Ethereum chain should appear
+      return <ConnectWalletButton chainId={1} />
+    } else if (toTokensCommonChainId && isStarknetChain(toTokensCommonChainId) && !snAccount) {
+      // If the 'To' tokens are on StarkNet, then a 'Connect' button with StarkNet chain should appear
       return <ConnectWalletButton chainId={toTokensCommonChainId} />
     } else {
+      // If none of these apply, then a 'Select tokens' disabled button should be displayed
       return <SwapButton disabled={isDisabled} />
     }
   } else if (inputCurrency && !srcWalletConnected) {


### PR DESCRIPTION
Previously, the action button was labeled "Review" until a user selected a token. Now, with this update, if preselected tokens are on the same chain, the action button carries the label "Connect <chain> wallet." Otherwise, the button is labeled "Select token".